### PR TITLE
Allow - in GitHub usernames and repo names

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,7 @@
 import { exec } from "./util";
 
 export function getRepo() {
-  const originReg = /:([A-Za-z0-9]+\/[A-Za-z0-9]+)\.git$/;
+  const originReg = /:([A-Za-z0-9-]+\/[A-Za-z0-9-]+)\.git$/;
   try {
     const raw = exec("git config --get remote.origin.url");
 


### PR DESCRIPTION
GitHub has many repos with hyphens as well as usernames with them (except at the beginning), so this allows changelogged to recognize these repos.